### PR TITLE
improvement suggestion feat: log history synthese module

### DIFF
--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -585,7 +585,6 @@ class SyntheseLogEntry(DB.Model):
     __table_args__ = {"schema": "gn_synthese"}
     query_class = SyntheseQuery
     id_synthese = DB.Column(DB.Integer(), primary_key=True)
-    unique_id_sinp = DB.Column(UUID(as_uuid=True))
     last_action = DB.Column(DB.Unicode)
     meta_last_action_date = DB.Column(DB.DateTime)
 

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 
 import sqlalchemy as sa
 import datetime
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, Unicode, and_
 from sqlalchemy.orm import (
     relationship,
     column_property,
@@ -22,6 +22,7 @@ from flask import g
 from flask_sqlalchemy import BaseQuery
 
 from werkzeug.exceptions import NotFound
+from werkzeug.datastructures import MultiDict
 
 from pypnnomenclature.models import TNomenclatures
 from pypnusershub.db.models import User
@@ -129,6 +130,37 @@ class SyntheseQuery(GeoFeatureCollectionMixin, BaseQuery):
             )
         return self
 
+    def _get_entity(self, entity):
+        if hasattr(entity, "_entities"):
+            return self._get_entity(entity._entities[0])
+        return entity.entities[0]
+
+    def _get_model(self):
+        # When sqlalchemy is updated:
+        # return self._raw_columns[0].entity_namespace
+        # But for now:
+        entity = self._get_entity(self)
+        return entity.c
+
+    def filter_by_params(self, params: MultiDict = None):
+        model = self._get_model()
+        and_list = []
+        for key, value in params.items():
+            column = getattr(model, key)
+            if isinstance(column.type, Unicode):
+                and_list.append(column.ilike(f"%{value}%"))
+            else:
+                and_list.append(column == value)
+        and_query = and_(*and_list)
+        return self.filter(and_query)
+
+    def sort(self, label: str, direction: str):
+        model = self._get_model()
+        order_by = getattr(model, label)
+        if direction == "desc":
+            order_by = order_by.desc()
+
+        return self.order_by(order_by)
 
 @serializable
 class CorAreaSynthese(DB.Model):
@@ -551,6 +583,7 @@ class SyntheseLogEntry(DB.Model):
 
     __tablename__ = "t_log_synthese"
     __table_args__ = {"schema": "gn_synthese"}
+    query_class = SyntheseQuery
     id_synthese = DB.Column(DB.Integer(), primary_key=True)
     unique_id_sinp = DB.Column(UUID(as_uuid=True))
     last_action = DB.Column(DB.Unicode)

--- a/backend/geonature/core/gn_synthese/models.py
+++ b/backend/geonature/core/gn_synthese/models.py
@@ -130,20 +130,9 @@ class SyntheseQuery(GeoFeatureCollectionMixin, BaseQuery):
             )
         return self
 
-    def _get_entity(self, entity):
-        if hasattr(entity, "_entities"):
-            return self._get_entity(entity._entities[0])
-        return entity.entities[0]
-
-    def _get_model(self):
-        # When sqlalchemy is updated:
-        # return self._raw_columns[0].entity_namespace
-        # But for now:
-        entity = self._get_entity(self)
-        return entity.c
 
     def filter_by_params(self, params: MultiDict = None):
-        model = self._get_model()
+        model = Synthese
         and_list = []
         for key, value in params.items():
             column = getattr(model, key)
@@ -155,7 +144,7 @@ class SyntheseQuery(GeoFeatureCollectionMixin, BaseQuery):
         return self.filter(and_query)
 
     def sort(self, label: str, direction: str):
-        model = self._get_model()
+        model = Synthese
         order_by = getattr(model, label)
         if direction == "desc":
             order_by = order_by.desc()

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -16,6 +16,7 @@ from flask import (
     g,
 )
 from werkzeug.exceptions import Forbidden, NotFound, BadRequest, Conflict
+from werkzeug.datastructures import MultiDict
 from sqlalchemy import distinct, func, desc, asc, select, text, update
 from sqlalchemy.orm import joinedload, contains_eager, lazyload, selectinload
 from geojson import FeatureCollection, Feature
@@ -42,11 +43,20 @@ from geonature.core.gn_synthese.models import (
     VSyntheseForWebApp,
     VColorAreaTaxon,
     TReport,
+    SyntheseLogEntry,
+    SyntheseQuery,
 
 )
 from geonature.core.gn_synthese.synthese_config import MANDATORY_COLUMNS
 
 from geonature.core.gn_synthese.utils.query_select_sqla import SyntheseQuery
+from geonature.core.gn_synthese.utils.routes import (
+    filter_params,
+    get_sort,
+    paginate,
+    get_limit_page,
+    sort,
+)
 
 from geonature.core.gn_permissions import decorators as permissions
 from geonature.core.gn_permissions.tools import (
@@ -1169,20 +1179,33 @@ def list_synthese_log_entries(info_role) -> dict:
         log action list
     """
 
-    limit = request.args.get("limit", default=1000, type=int)
-    offset = request.args.get("offset", default=0, type=int)
-
-    args = request.args.to_dict()
-    if "limit" in args:
-        args.pop("limit")
-    if "offset" in args:
-        args.pop("offset")
-    filters = {f: args.get(f) for f in args}
-
-    query = GenericQuery(
-        DB, "v_log_synthese", "gn_synthese", filters=filters, limit=limit, offset=offset
+    params = MultiDict(request.args)
+    limit, page = get_limit_page(params=params)
+    sort_label, sort_dir = get_sort(
+        params=params, default_sort="meta_last_action_date", default_direction="desc"
+    )
+    q1 = SyntheseLogEntry.query.with_entities(
+        SyntheseLogEntry.id_synthese,
+        SyntheseLogEntry.unique_id_sinp,
+        SyntheseLogEntry.last_action,
+        SyntheseLogEntry.meta_last_action_date,
     )
 
-    data = query.return_query()
+    q2 = Synthese.query.with_entities(
+        Synthese.id_synthese,
+        Synthese.unique_id_sinp,
+        Synthese.last_action,
+        func.coalesce(Synthese.meta_update_date, Synthese.meta_create_date),
+    )
+
+    q3 = q1.union(q2)
+
+    query = filter_params(query=q3, params=params)
+    query = sort(query=query, sort=sort_label, sort_dir=sort_dir)
+    data = paginate(
+        query=query,
+        limit=limit,
+        page=page,
+    )
 
     return data

--- a/backend/geonature/core/gn_synthese/routes.py
+++ b/backend/geonature/core/gn_synthese/routes.py
@@ -1186,14 +1186,12 @@ def list_synthese_log_entries(info_role) -> dict:
     )
     q1 = SyntheseLogEntry.query.with_entities(
         SyntheseLogEntry.id_synthese,
-        SyntheseLogEntry.unique_id_sinp,
         SyntheseLogEntry.last_action,
         SyntheseLogEntry.meta_last_action_date,
     )
 
     q2 = Synthese.query.with_entities(
         Synthese.id_synthese,
-        Synthese.unique_id_sinp,
         Synthese.last_action,
         func.coalesce(Synthese.meta_update_date, Synthese.meta_create_date),
     )

--- a/backend/geonature/core/gn_synthese/utils/routes.py
+++ b/backend/geonature/core/gn_synthese/utils/routes.py
@@ -1,0 +1,34 @@
+from typing import Tuple
+
+from flask import Response
+from sqlalchemy.orm import Query
+from werkzeug.datastructures import MultiDict
+
+from geonature.core.gn_synthese.models import SyntheseQuery
+
+
+def get_limit_page(params: MultiDict) -> Tuple[int]:
+    return int(params.pop("limit", 50)), int(params.pop("page", 1))
+
+
+def get_sort(params: MultiDict, default_sort: str, default_direction) -> Tuple[str]:
+    return params.pop("sort", default_sort), params.pop("sort_dir", default_direction)
+
+
+def paginate(query: Query, limit: int, page: int) -> Response:
+    result = query.paginate(page=page, error_out=False, per_page=limit)
+    data = dict(items=result.items, total=result.total, limit=limit, page=page)
+
+    return data
+
+
+def filter_params(query: SyntheseQuery, params: MultiDict) -> SyntheseQuery:
+    if len(params) != 0:
+        query = query.filter_by_params(params)
+    return query
+
+
+def sort(query: SyntheseQuery, sort: str, sort_dir: str) -> SyntheseQuery:
+    if sort_dir in ["desc", "asc"]:
+        query = query.sort(label=sort, direction=sort_dir)
+    return query

--- a/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
+++ b/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
@@ -30,57 +30,33 @@ def upgrade():
     op.execute(
         """
     CREATE OR REPLACE FUNCTION gn_synthese.fct_tri_log_delete_on_synthese() RETURNS TRIGGER AS
-$BODY$
-DECLARE
-BEGIN
-    -- log id/uuid of deleted datas into specific log table
-    IF (TG_OP = 'DELETE') THEN
-        INSERT INTO gn_synthese.t_log_synthese
-        SELECT
-            o.id_synthese    AS id_synthese
-            , o.unique_id_sinp AS unique_id_sinp
-            , 'D'                AS last_action
-            , now()              AS meta_last_action_date
-        from old_table o
-        ON CONFLICT (id_synthese)
-        DO UPDATE SET last_action = 'D', meta_last_action_date = now();
-    END IF;
-    RETURN NULL;
-END;
-$BODY$ LANGUAGE plpgsql COST 100
-;
-DROP TRIGGER IF EXISTS tri_log_delete_synthese ON gn_synthese.synthese;
-CREATE TRIGGER tri_log_delete_synthese
-    AFTER DELETE
-    ON gn_synthese.synthese
-    REFERENCING OLD TABLE AS old_table
-    FOR EACH STATEMENT
-EXECUTE FUNCTION gn_synthese.fct_tri_log_delete_on_synthese()
-;
-CREATE VIEW gn_synthese.v_log_synthese AS
-(
-WITH
-    t1 AS (SELECT
-               id_synthese
-             , unique_id_sinp
-             , last_action
-             , meta_last_action_date
-               FROM
-                   gn_synthese.t_log_synthese
-           UNION
-           SELECT
-               id_synthese
-             , unique_id_sinp
-             , last_action
-             , coalesce(meta_update_date, meta_create_date)
-               FROM
-                   gn_synthese.synthese)
-SELECT *
-    FROM
-        t1
-    ORDER BY
-        meta_last_action_date DESC)
-;
+    $BODY$
+    DECLARE
+    BEGIN
+        -- log id/uuid of deleted datas into specific log table
+        IF (TG_OP = 'DELETE') THEN
+            INSERT INTO gn_synthese.t_log_synthese
+            SELECT
+                o.id_synthese    AS id_synthese
+                , o.unique_id_sinp AS unique_id_sinp
+                , 'D'                AS last_action
+                , now()              AS meta_last_action_date
+            from old_table o
+            ON CONFLICT (id_synthese)
+            DO UPDATE SET last_action = 'D', meta_last_action_date = now();
+        END IF;
+        RETURN NULL;
+    END;
+    $BODY$ LANGUAGE plpgsql COST 100
+    ;
+    DROP TRIGGER IF EXISTS tri_log_delete_synthese ON gn_synthese.synthese;
+    CREATE TRIGGER tri_log_delete_synthese
+        AFTER DELETE
+        ON gn_synthese.synthese
+        REFERENCING OLD TABLE AS old_table
+        FOR EACH STATEMENT
+    EXECUTE FUNCTION gn_synthese.fct_tri_log_delete_on_synthese()
+    ;
     """
     )
 
@@ -89,7 +65,6 @@ def downgrade():
     op.drop_table("t_log_synthese", schema="gn_synthese")
     op.execute(
         """
-    DROP VIEW IF EXISTS gn_synthese.v_log_synthese;
     DROP TRIGGER IF EXISTS tri_log_delete_synthese ON gn_synthese.synthese;
     DROP FUNCTION gn_synthese.fct_tri_log_delete_on_synthese();    
     """

--- a/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
+++ b/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
@@ -22,7 +22,6 @@ def upgrade():
     op.create_table(
         "t_log_synthese",
         sa.Column("id_synthese", sa.Integer, primary_key=True),
-        sa.Column("unique_id_sinp", UUID(as_uuid=True), nullable=False),
         sa.Column("last_action", sa.CHAR(1), nullable=False),
         sa.Column("meta_last_action_date", sa.TIMESTAMP, server_default=sa.func.now()),
         schema="gn_synthese",
@@ -38,7 +37,6 @@ def upgrade():
             INSERT INTO gn_synthese.t_log_synthese
             SELECT
                 o.id_synthese    AS id_synthese
-                , o.unique_id_sinp AS unique_id_sinp
                 , 'D'                AS last_action
                 , now()              AS meta_last_action_date
             from old_table o

--- a/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
+++ b/backend/geonature/migrations/versions/9e9218653d6c_add_synthese_log_history.py
@@ -1,7 +1,7 @@
 """add synthese log history
 
 Revision ID: 9e9218653d6c
-Revises: ca0fe5d21ea2
+Revises: 0cae32a010ea
 Create Date: 2022-04-06 15:39:37.428357
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.sql.expression import null
 
 # revision identifiers, used by Alembic.
 revision = "9e9218653d6c"
-down_revision = "ca0fe5d21ea2"
+down_revision = "0cae32a010ea"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Proposition de travail sur la base des retours de la PR #1835.
Sur l'appui de ce commentaire : 
> Mise à jour du travail restant que nous allons effectuer :
> 
>     * [x]  Supprimer le paramètre LOG_API (superflu)
> 
>     * [ ]  Supprimer l’usage de GenericQuery : la manière fléché par SQLAlchemy pour cela serait d’utiliser query_class ; on peut envisager de faire des fonctions de filtrage générique de cette manière mais il faut que cela soit bien réfléchit et bien couvert par les tests.
> 
>     * [ ]  Supprimer la vue v_log_synthese (plus difficile à maintenir) au profit d’une requête d’union directement dans la route
> 
>     * [ ]  L’UUID est-il vraiment nécessaire ? Si non, ne garder que l’id_synthese
> 
>     * [x]  Renommer le modèle TLogSynthese en SyntheseLogEntry
> 
>     * [ ]  Vérifier la cohérence entre le modèle et le SQL de création de la table (par exemple, supprimer le NOT NULL sur le champs d’UUID dans le SQL)
> 
>     * [ ]  Écrire des tests unitaires
> 
>     * [x]  Fix des conflits et MaJ en v2.11
